### PR TITLE
fix crash when can not purchase server

### DIFF
--- a/ep1-ep3/auto-purchase-server.js
+++ b/ep1-ep3/auto-purchase-server.js
@@ -46,6 +46,14 @@ export async function main(ns) {
 		await copyAndRunVirus(server);
 	}
 
+	async function purchaseServer(server) {
+		while (!canPurchaseServer()) {
+			await ns.sleep(10000);
+		}
+		ns.purchaseServer(server, pRam);
+		await copyAndRunVirus(server);
+	}
+
 	async function autoUpgradeServers() {
 		var i = 0;
 		while (i < maxServers) {
@@ -54,10 +62,9 @@ export async function main(ns) {
 				ns.print("Upgrading server " + server + " to " + pRam + "GB");
 				await upgradeServer(server);
 				++i;
-			} else if (canPurchaseServer()) {
+			} else {
 				ns.print("Purchasing server " + server + " at " + pRam + "GB");
-				ns.purchaseServer(server, pRam);
-				await copyAndRunVirus(server);
+				await purchaseServer(server);
 				++i;
 			}
 		}

--- a/ep5-ep8/aps-lite.js
+++ b/ep5-ep8/aps-lite.js
@@ -28,6 +28,13 @@
 		}
 	}
 
+	async function purchaseServer(server) {
+		while (!canPurchaseServer()) {
+			await ns.sleep(10000); // wait 10s
+		}
+		ns.purchaseServer(server, pRam);
+	}
+
 	async function autoUpgradeServers() {
 		var i = 0;
 		while (i < maxServers) {
@@ -36,9 +43,9 @@
 				ns.print("Upgrading server " + server + " to " + pRam + "GB");
 				await upgradeServer(server);
 				++i;
-			} else if (canPurchaseServer()) {
+			} else {
 				ns.print("Purchasing server " + server + " at " + pRam + "GB");
-				ns.purchaseServer(server, pRam);
+				await purchaseServer(server, pRam);
 				++i;
 			}
 		}


### PR DESCRIPTION
I was having the same issue as Simon Garza and bdavi485 on [Automatically purchase and upgrade servers - Bitburner #2](https://youtu.be/zaxHSOVB2SU). I believe the issue is due to the `autoUpgradeServers` function not considering what to do when the player is unable to purchase a new server. This can be tested by hard setting `canPurchaseServer` to return `false`. I believe I have addressed the issue by waiting 10 seconds when unable to purchase (following the same pattern as `upgradeServer`). This same issue arises in a later episode with aps-lite.js.