### PR TITLE
Change find-targets.js to display percentage

### DIFF
--- a/ep4/find-targets.js
+++ b/ep4/find-targets.js
@@ -13,6 +13,9 @@ export async function main(ns) {
 		var server = ns.getServer(node);
 		var maxMoney = ns.getServerMaxMoney(node);
 		var chance = ns.formulas.hacking.hackChance(server, player);
+		chance = chance * 100;
+		chance = Math.round((chance + Number.EPSILON) * 100) / 100;
+		chance = chance + "%"
 		var reqHackLevel = ns.getServerRequiredHackingLevel(node);
 		return {
 			node,


### PR DESCRIPTION
I've changed the code to display the hacking chance as a correct percentage to two decimal places. As an example, 0.42306 will be displayed as 42.31%.