### PR TITLE
Update ap-hacknet-node.js

### DIFF
--- a/_stable/ap-hacknet-node.js
+++ b/_stable/ap-hacknet-node.js
@@ -187,5 +187,6 @@ export async function main(ns) {
 		const nodesToUpgrade = getBestNodesToUpgrade(nodes);
 		const purchaseInfo = getPurchaseInfo();
 		await doNextAction(purchaseInfo, nodesToUpgrade);
+		await ns.sleep(1000);
 	}
 }


### PR DESCRIPTION
After the  v1.7.0 update script kept crashing due to infinite loop.
needed to add a   await ns.sleep(1000) to the while loop at line 190 to stop the crash.