### PR TITLE
fixed ns.stock format

### DIFF
--- a/_stable/diamond-hands.js
+++ b/_stable/diamond-hands.js
@@ -51,7 +51,7 @@ export async function main(ns) {
 			overallValue += curValue;
 		} else {
 			// Take tendies!
-			const salePrice = ns.stock.sell(stock.sym, stock.longShares);
+			const salePrice = ns.stock.sellStock(stock.sym, stock.longShares);
 			const saleTotal = salePrice * stock.longShares;
 			const saleCost = stock.longPrice * stock.longShares;
 			const saleProfit = saleTotal - saleCost - tradeFees;
@@ -77,7 +77,7 @@ export async function main(ns) {
 				if (money > riskThresh) {
 					const sharesWeCanBuy = Math.floor((money - fees) / stock.askPrice);
 					const sharesToBuy = Math.min(stock.maxShares, sharesWeCanBuy);
-					if (ns.stock.buy(stock.sym, sharesToBuy) > 0) {
+					if (ns.stock.buyStock(stock.sym, sharesToBuy) > 0) {
 						ns.print(`WARN\t${stock.summary}\t- LONG @ ${ns.nFormat(sharesToBuy, "$0.0a")}`);
 					}
 				}

--- a/_stable/diamond-hands.js
+++ b/_stable/diamond-hands.js
@@ -72,7 +72,7 @@ export async function main(ns) {
 	function yolo(stocks) {
 		const riskThresh = 20 * fees;
 		for (const stock of stocks) {
-			const money = ns.getPlayer().money;
+			const money = ns.getPlayer().money * 0.25; //Limit the money used to 25% of player funds
 			if (stock.forecast > 0.55) {
 				if (money > riskThresh) {
 					const sharesWeCanBuy = Math.floor((money - fees) / stock.askPrice);


### PR DESCRIPTION
There was a change in how ns.stock api looked for buying and selling since this was originally written. ns.stock.sell replaced with ns.stock.sellStock and the same for the buy version.

This should help anyone who tries to clone after watching the tutorials.