### PR TITLE
Hashnet servers exclusion

### DIFF
--- a/_stable/launch-fleets.js
+++ b/_stable/launch-fleets.js
@@ -42,7 +42,7 @@ export async function main(ns) {
 	async function getShips() {
 		var nodes = getNetworkNodes(ns);
 		var servers = nodes.filter(node => {
-			if (node === homeServ) {
+			if (node === homeServ || node.includes('hacknet-server-')) {
 				return false;
 			}
 			return canPenetrate(ns, node, cracks) && hasRam(ns, node, virusRam);


### PR DESCRIPTION
After unlocking the Hacknet servers, they appear in the network and you can run scripts on them. 
However, their profit generation reduces a lot if their RAM is fully used. All things considered, it's more profitable to leave these servers alone.